### PR TITLE
[ISSUE #73] Update blog post dates - display original and updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ Images used directly in the blog are currently found in the `static` directory. 
 
 > For a blog post to have properly formatted dates you must include the date in the blog posts markdown frontmatter
 
+Note there are two types of dates associated to each blog post:
+
+- datePublished
+- dateModified
+
+The motivation for these is to help the reader assess the relevance of the content.  My goal is to have posts that will continue to be useful as the blog ages so I don't have to continue rewriting everything as I go.
+
 ### Summary
 
 `gatsby-transformer-remark` will provide you with what they call an `excerpt` of the content in your markdown file. The `excerpt` is the first 140 characters of your markdown file. While you can set it to be whatever you like, I prefer custom excerpts. Thus, to add a custom excerpt you must add a `summary` field to your `frontmatter`. Please limit to 140 characters.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
   - [Summary](#summary)
   - [Slug](#slug)
   - [Footnotes](#footnotes)
-  - [Keywords](#keywords)
   - [Article Notes](#article-notes)
   - [Images](#images)
   - [Edits](#edits)
@@ -185,19 +184,6 @@ Footnotes are great when you have additional clarifying comments or want to cred
 We provide aria-labels for everything and we also add an `aside` at the bottom which is where we put the footers.
 
 Note that you do not need to manually add numbers to the footnotes. This is because we have setup the CSS to dynamically count your footnotes. Having said this, you do need to put them in the correct order in the aside section at the bottom.
-
-### Keywords
-
-`keywords` refer to seo keywords.  Should be written as a vector like:
-
-```markdown
----
-title: 'What the Reagent Component?!'
-date: '2019-07-29'
-...
-keywords: ['reagent', 'class components', 'clojurescript']
----
-```
 
 ### Article Notes
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -28,26 +28,26 @@ module.exports = {
         title: 'Articles',
         url: '/',
         iconName: '',
-        isInternalLink: true
+        isInternalLink: true,
       },
       {
         title: 'Subscribe',
         url: '/subscribe',
         iconName: '',
-        isInternalLink: true
+        isInternalLink: true,
       },
       {
         title: 'Contact',
         url: 'mailto:thomasmattacchione@gmail.com?Subject=Hi%20Thomas',
         iconName: '',
-        isInternalLink: false
+        isInternalLink: false,
       },
       {
         title: 'Youtube',
         url:
           'https://www.youtube.com/channel/UCfBUN43AQoyGiQxmCIDZe2w/featured?view_as=subscriber',
         iconName: 'youtube',
-        isInternalLink: false
+        isInternalLink: false,
       },
     ],
     footerlinks: [
@@ -103,12 +103,70 @@ module.exports = {
         id: 'MERGE0',
       },
       submitBtn: 'Subscribe',
-    }
+    },
   },
   plugins: [
-    `gatsby-plugin-feed`,
+    {
+      resolve: `gatsby-plugin-feed`,
+      options: {
+        query: `
+          {
+            site {
+              siteMetadata {
+                title
+                description
+                siteUrl
+                site_url: siteUrl
+              }
+            }
+          }
+        `,
+        feeds: [
+          {
+            serialize: ({ query: { site, allMarkdownRemark } }) => {
+              return allMarkdownRemark.edges.map((edge) => {
+                return Object.assign({}, edge.node.frontmatter, {
+                  description: edge.node.excerpt,
+                  date: edge.node.frontmatter.datePublished,
+                  url: site.siteMetadata.siteUrl + edge.node.fields.slug,
+                  guid: site.siteMetadata.siteUrl + edge.node.fields.slug,
+                  custom_elements: [{ 'content:encoded': edge.node.html }],
+                })
+              })
+            },
+            query: `
+              {
+                allMarkdownRemark(
+                  sort: { order: DESC, fields: [frontmatter___datePublished] },
+                ) {
+                  edges {
+                    node {
+                      excerpt
+                      html
+                      fields { slug }
+                      frontmatter {
+                        title
+                        datePublished
+                      }
+                    }
+                  }
+                }
+              }
+            `,
+            output: '/rss.xml',
+            title: 'Between Two Parens RSS Feed',
+            // optional configuration to insert feed reference in pages:
+            // if `string` is used, it will be used to create RegExp and then test if pathname of
+            // current page satisfied this regular expression;
+            // if not provided or `undefined`, all pages will have feed reference inserted
+            match: '^/blog/',
+          },
+        ],
+      },
+    },
     `gatsby-plugin-sharp`,
     `gatsby-plugin-react-helmet`,
+
     {
       resolve: `gatsby-source-filesystem`,
       options: {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -16,7 +16,7 @@ module.exports = {
     seoLang: `en`,
     seoDescription: `A blog about programming clojure, clojurescript and javascript`,
     ogURL: `https://www.betweentwoparens.com`,
-    seokeywords: [`clojurescript`, `clojure`, `javascript`],
+    interests: [`clojurescript`, `clojure`, `javascript`],
     // added for the RSS feed plugin
     siteUrl: `https://betweentwoparens.com`,
     license: {

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -11,8 +11,6 @@ function SEO({
   ogURL,
   datePublished,
   dateModified,
-  // object with keys: title, author, datePublished, description
-  googleStructuredData,
   isBlogPost,
 }) {
   return (

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -1,103 +1,88 @@
 import React from 'react'
-import PropTypes from 'prop-types'
-import {Helmet} from 'react-helmet'
-import favicon from '../assets/thomas.ico';
+import { Helmet } from 'react-helmet'
+import favicon from '../assets/thomas.ico'
 
-function SEO({ description, lang, meta, keywords, title, author, ogURL }) {
+function SEO({
+  description,
+  lang,
+  meta,
+  title,
+  author,
+  ogURL,
+  datePublished,
+  dateModified,
+  // object with keys: title, author, datePublished, description
+  googleStructuredData,
+  isBlogPost,
+}) {
   return (
-    <Helmet
-      htmlAttributes={{
-        lang,
-      }}
-      title={title}
-      titleTemplate={title}
-      link={[
+    <Helmet>
+      <html lang={lang} />
+
+      {/* General tags */}
+      <title>{title}</title>
+      <meta name="description" content={description} />
+      <meta
+        name="image"
+        content={`https://betweentwoparens.com/thomas-cartoon.jpeg`}
+      />
+
+      {/* OpenGraph tags */}
+      <meta property="og:url" content={ogURL} />
+      <meta property="og:type" content="website" />
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta
+        property="og:image"
+        content={`https://betweentwoparens.com/thomas-cartoon.jpeg`}
+      />
+
+      {/* Twitter Card tags */}
+      <meta name="twitter:card" content="summary" />
+      <meta name="twitter:creator" content={author} />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
+      <meta
+        name="twitter:image"
+        content={`https://betweentwoparens.com/thomas-cartoon.jpeg`}
+      />
+
+      {/* Structured Data - https://developers.google.com/search/docs/data-types/article#non-amp*/}
+      {isBlogPost ? (
+        <script type="application/ld+json">{`
         {
-          href:
-            'https://fonts.googleapis.com/css?family=Noto+Sans:400,700&display=swap',
-          rel: 'stylesheet',
-        },
-        {
-          href: 'https://fonts.googleapis.com/css?family=Playfair+Display&display=swap',
-          rel: 'stylesheet'
-        },
-        {
-          href: 'https://fonts.googleapis.com/css?family=Roboto:300i,700&display=swap',
-          rel: 'stylesheet'
-        },
-        { rel: 'shortcut icon', type: 'image/png', href: `${favicon}` }
-      ]}
-      meta={[
-        {
-          name: `description`,
-          content: description,
-        },
-        {
-          property: `og:title`,
-          content: title,
-        },
-        {
-          property: `og:description`,
-          content: description,
-        },
-        {
-          property: `og:type`,
-          content: `website`,
-        },
-        {
-          property: `og:image`,
-          content: `https://betweentwoparens.com/thomas-cartoon.jpeg`,
-        },
-        {
-          property: `og:url`,
-          content: ogURL,
-        },
-        {
-          name: `twitter:card`,
-          content: `summary`,
-        },
-        {
-          name: `twitter:image`,
-          content: `https://betweentwoparens.com/thomas-cartoon.jpeg`
-        },
-        {
-          name: `twitter:creator`,
-          content: author,
-        },
-        {
-          name: `twitter:title`,
-          content: title,
-        },
-        {
-          name: `twitter:description`,
-          content: description,
-        },
-      ]
-        .concat(
-          keywords.length > 0
-            ? {
-                name: `keywords`,
-                content: keywords.join(`, `),
-              }
-            : []
-        )
-        .concat(meta)}
-    />
+            "@context": "http://schema.org",
+            "@type": "Article",
+            "name": ${title},
+            "author": {
+              "@type": "Person",
+              "name": ${author}
+            },
+            "datePublished": ${datePublished},
+            "dateModified": ${dateModified},
+        }
+    `}</script>
+      ) : (
+        false
+      )}
+
+      {/* stylesheets */}
+
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css?family=Noto+Sans:400,700&display=swap"
+      />
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css?family=Playfair+Display&display=swap"
+      />
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css?family=Roboto:300i,700&display=swap"
+      />
+      <link rel="shortcut icon" type="image/png" href={favicon} />
+    </Helmet>
   )
-}
-
-SEO.defaultProps = {
-  lang: `en`,
-  meta: [],
-  keywords: [],
-}
-
-SEO.propTypes = {
-  description: PropTypes.string,
-  lang: PropTypes.string,
-  meta: PropTypes.array,
-  keywords: PropTypes.arrayOf(PropTypes.string),
-  title: PropTypes.string.isRequired,
 }
 
 export default SEO

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -51,13 +51,13 @@ function SEO({
         {
             "@context": "http://schema.org",
             "@type": "Article",
-            "name": ${title},
+            "name": "${title}",
             "author": {
               "@type": "Person",
-              "name": ${author}
+              "name": "${author}"
             },
-            "datePublished": ${datePublished},
-            "dateModified": ${dateModified},
+            "datePublished": "${datePublished}",
+            "dateModified": "${dateModified}"
         }
     `}</script>
       ) : (

--- a/src/pages/blog-posts/000-deploy-clojurescript-to-github-pages.md
+++ b/src/pages/blog-posts/000-deploy-clojurescript-to-github-pages.md
@@ -1,7 +1,8 @@
 ---
 title: 'Deploy ClojureScript to Github Pages'
 author: Thomas Mattacchione
-date: '2019-05-20'
+datePublished: '2019-05-20'
+dateModified: '2020-05-26'
 slug: deoploy-clojurescript-to-github-pages
 summary: How to build a static site in ClojureScript in probably 2.5 minutes
 keywords: ['deploy', 'clojurescript', 'github']

--- a/src/pages/blog-posts/000-deploy-clojurescript-to-github-pages.md
+++ b/src/pages/blog-posts/000-deploy-clojurescript-to-github-pages.md
@@ -5,7 +5,6 @@ datePublished: '2019-05-20'
 dateModified: '2020-05-26'
 slug: deoploy-clojurescript-to-github-pages
 summary: How to build a static site in ClojureScript in probably 2.5 minutes
-keywords: ['deploy', 'clojurescript', 'github']
 ---
 
 This blog will guide you through the process of building and deploying a minimal static website to Github Pages. By the end we should see how straightforward and accessible working with ClojureScript has become. Before we dive in, let's introduce the key players.

--- a/src/pages/blog-posts/001-creating-a-clojurescript-project-from-scratch.md
+++ b/src/pages/blog-posts/001-creating-a-clojurescript-project-from-scratch.md
@@ -5,7 +5,6 @@ dateModified: '2020-07-05'
 slug: start-a-clojurescript-app-from-scratch
 summary: 'A guide to setting up a ClojureScript app from scratch without fear or worry.'
 author: 'Thomas Mattacchione'
-keywords: ['clojurescript', 'start', 'new']
 ---
 
 Welcome to my step by step guide to setting up a ClojureScript app. We'll work to assuage your fears & stresses and alleviate those nagging thoughts about doing things the "right" or "wrong" way.

--- a/src/pages/blog-posts/001-creating-a-clojurescript-project-from-scratch.md
+++ b/src/pages/blog-posts/001-creating-a-clojurescript-project-from-scratch.md
@@ -1,6 +1,7 @@
 ---
 title: 'Start a ClojureScript App from Scratch'
-date: '2019-06-24'
+datePublished: '2019-06-24'
+dateModified: '2020-07-05'
 slug: start-a-clojurescript-app-from-scratch
 summary: 'A guide to setting up a ClojureScript app from scratch without fear or worry.'
 author: 'Thomas Mattacchione'

--- a/src/pages/blog-posts/002-what-the-reagent-component.md
+++ b/src/pages/blog-posts/002-what-the-reagent-component.md
@@ -1,6 +1,7 @@
 ---
 title: 'What the Reagent Component?!'
-date: '2019-07-29'
+datePublished: '2019-07-29'
+dateModified: '2020-04-03'
 slug: what-the-reagent-component
 summary: It's time to uncover the truth about Reagent components
 author: 'Thomas Mattacchione'

--- a/src/pages/blog-posts/002-what-the-reagent-component.md
+++ b/src/pages/blog-posts/002-what-the-reagent-component.md
@@ -5,7 +5,6 @@ dateModified: '2020-04-03'
 slug: what-the-reagent-component
 summary: It's time to uncover the truth about Reagent components
 author: 'Thomas Mattacchione'
-keywords: ['reagent', 'class components', 'clojurescript']
 ---
 
 Did you know that when you write a [form-1](https://github.com/reagent-project/reagent/blob/master/doc/CreatingReagentComponents.md#form-1-a-simple-function), [form-2](https://github.com/reagent-project/reagent/blob/master/doc/CreatingReagentComponents.md#form-2--a-function-returning-a-function) or [form-3](https://github.com/reagent-project/reagent/blob/master/doc/CreatingReagentComponents.md#form-3-a-class-with-life-cycle-methods) Reagent component they all become React `class components`<a href="#reagent-components" aria-describedby="footnote-label" id="reagent-components-ref">?</a>

--- a/src/pages/blog-posts/003-testing-clojurescript.md
+++ b/src/pages/blog-posts/003-testing-clojurescript.md
@@ -1,6 +1,7 @@
 ---
 title: 'ClojureScript Test Setup'
-date: '2019-08-26'
+datePublished: '2019-08-26'
+dateModified: '2020-05-26'
 slug: clojurescript-test-setup
 summary: Setup a ClojureScript Test Toolchain like a Boss
 author: 'Thomas Mattacchione'

--- a/src/pages/blog-posts/003-testing-clojurescript.md
+++ b/src/pages/blog-posts/003-testing-clojurescript.md
@@ -5,7 +5,6 @@ dateModified: '2020-05-26'
 slug: clojurescript-test-setup
 summary: Setup a ClojureScript Test Toolchain like a Boss
 author: 'Thomas Mattacchione'
-keywords: ['test setup', 'test tools', 'clojurescript']
 ---
 
 ClojureScript rewards you for having more than a passing acquaintance with software testing practices. The community has provided great tools, but you do need to know how, why and when to use them<a href="#intro-to-testing" aria-describedby="footnote-label" id="intro-to-testing-ref">.</a>

--- a/src/pages/blog-posts/004-reloadable-code.md
+++ b/src/pages/blog-posts/004-reloadable-code.md
@@ -1,6 +1,7 @@
 ---
 title: 'Students of the Game: Reloadable Code'
-date: '2019-09-29'
+datePublished: '2019-09-29'
+dateModified: '2020-04-03'
 slug: students-of-the-game-reloadable-code
 summary: This is for the students of the game, the ones who want to reloadable code.
 author: 'Thomas Mattacchione'

--- a/src/pages/blog-posts/004-reloadable-code.md
+++ b/src/pages/blog-posts/004-reloadable-code.md
@@ -5,7 +5,6 @@ dateModified: '2020-04-03'
 slug: students-of-the-game-reloadable-code
 summary: This is for the students of the game, the ones who want to reloadable code.
 author: 'Thomas Mattacchione'
-keywords: ['clojurescript tutorial', 'figwheel', 'clojurescript']
 ---
 
 About two years ago I built a small ClojureScript app that looks like this:

--- a/src/pages/blog-posts/005-deploy-clojurescript-on-nginx.md
+++ b/src/pages/blog-posts/005-deploy-clojurescript-on-nginx.md
@@ -5,7 +5,6 @@ dateModified: '2020-05-26'
 slug: deploy-clojurescript-on-nginx
 summary: Learn how to serve a ClojureScript project on Nginx
 author: 'Thomas Mattacchione'
-keywords: ['clojurescript tutorial', 'docker clojurescript', 'clojurescript nginx']
 ---
 
 My [first blog post](https://betweentwoparens.com/deoploy-clojurescript-to-github-pages) outlined how to deploy a static ClojureScript website to Github Pages. This is an excellent choice for personal websites, or an open source project's documentation because you get free hosting infrastructure with relatively little effort.  Having said this, what happens if you can't use static hosting providers like Github Pages or [Netlify](https://www.netlify.com/)?  What if you need to control more of the hosting service?  This post will show you how to deploy your ClojureScript site on a webserver you control.  Specifically, we will cover the following topics:

--- a/src/pages/blog-posts/005-deploy-clojurescript-on-nginx.md
+++ b/src/pages/blog-posts/005-deploy-clojurescript-on-nginx.md
@@ -1,6 +1,7 @@
 ---
 title: 'Deploy ClojureScript on Nginx'
-date: '2019-10-29'
+datePublished: '2019-10-29'
+dateModified: '2020-05-26'
 slug: deploy-clojurescript-on-nginx
 summary: Learn how to serve a ClojureScript project on Nginx
 author: 'Thomas Mattacchione'

--- a/src/pages/blog-posts/006-clojure-text-editors.md
+++ b/src/pages/blog-posts/006-clojure-text-editors.md
@@ -5,7 +5,6 @@ dateModified: '2020-05-26'
 slug: clojure-text-editors
 summary: Focus on learning and writing Clojure!
 author: 'Thomas Mattacchione'
-keywords: ['clojurescript tutorial', 'atom github clojurescript', 'atom clojure']
 ---
 
 <aside class="blog-content__note">Interested in jumping right to my editor setup? <a class="blog-content__link" href="#my-text-editor-setup">click here</a> or you can checkout my free <a class="blog-content__link" target="_blank" rel="noopener noreferrer" href="https://www.youtube.com/playlist?list=PLaGDS2KB3-AqeOryQptgApJ6M7mfoFXIp">Atom Setup Guide Video Series</a>.</aside>

--- a/src/pages/blog-posts/006-clojure-text-editors.md
+++ b/src/pages/blog-posts/006-clojure-text-editors.md
@@ -1,6 +1,7 @@
 ---
 title: 'Clojure Text Editors'
-date: '2019-11-30'
+datePublished: '2019-11-30'
+dateModified: '2020-05-26'
 slug: clojure-text-editors
 summary: Focus on learning and writing Clojure!
 author: 'Thomas Mattacchione'

--- a/src/pages/blog-posts/007-reagent-and-hiccup.md
+++ b/src/pages/blog-posts/007-reagent-and-hiccup.md
@@ -1,6 +1,7 @@
 ---
 title: 'Reagent & Hiccup'
-date: '2019-12-31'
+datePublished: '2019-12-31'
+dateModified: '2020-07-06'
 slug: reagent-and-hiccup
 summary: Hiccup is the Ryan Atwood to JSX's Seth Cohen
 author: 'Thomas Mattacchione'

--- a/src/pages/blog-posts/007-reagent-and-hiccup.md
+++ b/src/pages/blog-posts/007-reagent-and-hiccup.md
@@ -5,7 +5,6 @@ dateModified: '2020-07-06'
 slug: reagent-and-hiccup
 summary: Hiccup is the Ryan Atwood to JSX's Seth Cohen
 author: 'Thomas Mattacchione'
-keywords: ['Reagent Hiccup', 'ClojureScript', 'Hiccup Guide']
 ---
 
 Let's start this post by looking at React's [hello world](https://reactjs.org/docs/hello-world.html) example:

--- a/src/pages/blog-posts/008-manage-your-java-jdks.md
+++ b/src/pages/blog-posts/008-manage-your-java-jdks.md
@@ -1,6 +1,7 @@
 ---
 title: 'Manage your Java JDKs'
-date: '2020-01-31'
+datePublished: '2020-01-31'
+dateModified: '2020-03-24'
 slug: jenv
 summary: Live like Jay
 author: 'Thomas Mattacchione'

--- a/src/pages/blog-posts/008-manage-your-java-jdks.md
+++ b/src/pages/blog-posts/008-manage-your-java-jdks.md
@@ -5,7 +5,6 @@ dateModified: '2020-03-24'
 slug: jenv
 summary: Live like Jay
 author: 'Thomas Mattacchione'
-keywords: ['java tutorial', 'jenv tutorial', 'java guide']
 ---
 
 Pro tip for anyone working with _any_ programming language: seek out a language version management tool.

--- a/src/pages/blog-posts/009-what-are-the-clojure-tools.md
+++ b/src/pages/blog-posts/009-what-are-the-clojure-tools.md
@@ -1,6 +1,7 @@
 ---
 title: 'What are the Clojure Tools?'
-date: '2020-03-31'
+datePublished: '2020-03-31'
+dateModified: '2020-08-10'
 slug: what-are-the-clojure-tools
 summary: It's not a build tool, it's clj
 author: 'Thomas Mattacchione'

--- a/src/pages/blog-posts/009-what-are-the-clojure-tools.md
+++ b/src/pages/blog-posts/009-what-are-the-clojure-tools.md
@@ -5,7 +5,6 @@ dateModified: '2020-08-10'
 slug: what-are-the-clojure-tools
 summary: It's not a build tool, it's clj
 author: 'Thomas Mattacchione'
-keywords: ['clojure tutorial', 'clojurescript beginner guide', 'clojure tools', 'clj']
 ---
 
 When I start learning a new language I like to begin by understanding the tooling ecosystem.  For me, having a handle on the tools enables me to confidently focus on learning the language itself<a href="#my-way" aria-describedby="footnote-label" id="my-way-ref">.</a>  For example, when I came to Clojure my questions went something like this:

--- a/src/pages/blog-posts/010-rich-comments.md
+++ b/src/pages/blog-posts/010-rich-comments.md
@@ -1,6 +1,7 @@
 ---
 title: 'Rich Comment Blocks'
-date: '2020-07-02'
+datePublished: '2020-07-02'
+dateModified: '2020-07-08'
 slug: rich-comment-blocks
 summary: Your coding life doesn't have to be a Rogue Like
 author: 'Thomas Mattacchione'

--- a/src/pages/blog-posts/010-rich-comments.md
+++ b/src/pages/blog-posts/010-rich-comments.md
@@ -5,7 +5,6 @@ dateModified: '2020-07-08'
 slug: rich-comment-blocks
 summary: Your coding life doesn't have to be a Rogue Like
 author: 'Thomas Mattacchione'
-keywords: ['clojure comment', 'Clojure Guide', 'Rich Hickey', 'Rich Comment']
 ---
 
 The three main types of comments in Clojure are

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -50,13 +50,12 @@ const IndexPage = ({ data }) => {
         author={siteMetadata.author}
         lang={siteMetadata.seoLang}
         ogURL={siteMetadata.ogURL}
-        keywords={siteMetadata.seokeywords}
       />
       <Header
         title={siteMetadata.title}
         name={siteMetadata.author}
         description={siteMetadata.description}
-        interests={siteMetadata.seokeywords}
+        interests={siteMetadata.interests}
         navList={siteMetadata.headerLinks}
       />
       <Blogs
@@ -78,7 +77,7 @@ export const query = graphql`
         seoTitle
         seoDescription
         seoLang
-        seokeywords
+        interests
         ogURL
         headerLinks {
           title

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -17,7 +17,7 @@ const Blogs = ({ blogPosts, emptyBlogMsg, footerLinks, license }) => {
               key={blogPost.node.id}
               title={blogPost.node.frontmatter.title}
               author={blogPost.node.frontmatter.author}
-              date={blogPost.node.frontmatter.date}
+              date={blogPost.node.frontmatter.datePublished}
               description={blogPost.node.frontmatter.summary}
               url={blogPost.node.fields.slug}
             />
@@ -97,7 +97,7 @@ export const query = graphql`
         }
       }
     }
-    allMarkdownRemark(sort: { fields: [frontmatter___date], order: DESC }) {
+    allMarkdownRemark(sort: { fields: [frontmatter___datePublished], order: DESC }) {
       totalCount
       edges {
         node {
@@ -105,7 +105,7 @@ export const query = graphql`
           frontmatter {
             title
             author
-            date(formatString: "DD MMMM, YYYY")
+            datePublished(formatString: "DD MMMM, YYYY")
             summary
           }
           fields {

--- a/src/pages/subscribe.js
+++ b/src/pages/subscribe.js
@@ -79,7 +79,6 @@ const SubscribePage = ({ data }) => {
         author={siteMetadata.author}
         lang={siteMetadata.seoLang}
         ogURL={siteMetadata.ogURL}
-        keywords={siteMetadata.seokeywords}
       />
       <div className="subscribe">
         <h1 className="h__base h__1 subscribe__title">Join Us</h1>
@@ -142,7 +141,6 @@ export const query = graphql`
         seoTitle
         seoDescription
         seoLang
-        seokeywords
         ogURL
 
         subscribe {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -326,11 +326,16 @@ They are: notes, code blocks, lists */
   margin: 0;
   color: var(--color-black);
   text-align: center;
-  text-transform: uppercase;
+}
+
+.blog-content__byline-time-wrapper {
+  display: flex;
+  margin-bottom: 20px;
 }
 
 .blog-content__byline-time {
-  margin-bottom: 20px;
+  text-transform: uppercase;
+  font-weight: bold;
 }
 
 .blog-content__byline-divider {

--- a/src/templates/blog-content.js
+++ b/src/templates/blog-content.js
@@ -24,15 +24,20 @@ const TableOfContents = ({ toc }) => {
   )
 }
 
-const BlogHeading = ({ title, date }) => {
+const BlogHeading = ({ title, datePublished, dateModified }) => {
   return (
     <div className="blog-content__heading">
       <h2 className="blog-content__headline">{title}</h2>
-      <p className="blog-content__byline">
-        <span className="hide">posted on</span>
-        <time className="blog-content__byline-time">{date}</time>
+      <div className="blog-content__byline">
+        <div className="blog-content__byline-time-wrapper">
+          <p className="">posted on
+            <time className="blog-content__byline-time"> {datePublished} </time>
+            and last updated
+            <time className="blog-content__byline-time"> {dateModified} </time>
+          </p>
+        </div>
         <span className="blog-content__byline-divider" />
-      </p>
+      </div>
     </div>
   )
 }
@@ -67,7 +72,11 @@ export default ({ data }) => {
         navList={siteMetadata.headerLinks}
       />
       <div className="blog-content__wrapper">
-        <BlogHeading title={frontmatter.title} date={frontmatter.date} />
+        <BlogHeading
+          title={frontmatter.title}
+          datePublished={frontmatter.datePublished}
+          dateModified={frontmatter.dateModified}
+        />
         <TableOfContents toc={data.markdownRemark.tableOfContents} />
         <BlogContent
           html={data.markdownRemark.html}
@@ -112,7 +121,8 @@ export const query = graphql`
         summary
         author
         slug
-        date(formatString: "DD MMMM, YYYY")
+        datePublished(formatString: "DD MMMM, YYYY")
+        dateModified(formatString: "DD MMMM, YYYY")
         keywords
       }
     }

--- a/src/templates/blog-content.js
+++ b/src/templates/blog-content.js
@@ -30,7 +30,8 @@ const BlogHeading = ({ title, datePublished, dateModified }) => {
       <h2 className="blog-content__headline">{title}</h2>
       <div className="blog-content__byline">
         <div className="blog-content__byline-time-wrapper">
-          <p className="">posted on
+          <p className="">
+            posted on
             <time className="blog-content__byline-time"> {datePublished} </time>
             and last updated
             <time className="blog-content__byline-time"> {dateModified} </time>
@@ -62,8 +63,11 @@ export default ({ data }) => {
         description={frontmatter.summary}
         author={frontmatter.author}
         lang={siteMetadata.seoLang}
+        googleStructuredData={''}
         ogURL={`${siteMetadata.ogURL}/${frontmatter.slug}`}
-        keywords={frontmatter.keywords}
+        datePublished={frontmatter.datePublished}
+        dateModified={frontmatter.dateModified}
+        isBlogPost={true}
       />
       <Header
         title={siteMetadata.title}

--- a/src/templates/blog-content.js
+++ b/src/templates/blog-content.js
@@ -63,7 +63,6 @@ export default ({ data }) => {
         description={frontmatter.summary}
         author={frontmatter.author}
         lang={siteMetadata.seoLang}
-        googleStructuredData={''}
         ogURL={`${siteMetadata.ogURL}/${frontmatter.slug}`}
         datePublished={frontmatter.datePublished}
         dateModified={frontmatter.dateModified}
@@ -127,7 +126,6 @@ export const query = graphql`
         slug
         datePublished(formatString: "DD MMMM, YYYY")
         dateModified(formatString: "DD MMMM, YYYY")
-        keywords
       }
     }
   }


### PR DESCRIPTION
resolves #73 

This includes the visual aspects for users, but also we add in some google structured data for SEO support.

structured data can be tested at https://search.google.com/test/rich-results

<img width="1353" alt="Screen Shot 2020-08-16 at 3 57 09 PM" src="https://user-images.githubusercontent.com/8523922/90342830-321ed480-dfd9-11ea-8fb3-373764f10884.png">
