### PR TITLE
fix typo in "What the Reagent Component?!" article

### DIFF
--- a/src/pages/blog-posts/002-what-the-reagent-component.md
+++ b/src/pages/blog-posts/002-what-the-reagent-component.md
@@ -171,7 +171,7 @@ At this point we are ready to return to Reagent's `create-class` function and ex
 
 ## The Reagent Pattern
 
-As noted, the history lesson from the above section should provide a little insight into the tribal knowledge that is informing how `create-class` is being implemented.   Namely this is becausse what `create-class` is doing is implementing a modified version of the `pseudoclassical instantiation pattern`.  The following code snippet is a simplified version of some of the essential bits of `create-class`:
+As noted, the history lesson from the above section should provide a little insight into the tribal knowledge that is informing how `create-class` is being implemented.   Namely this is because what `create-class` is doing is implementing a modified version of the `pseudoclassical instantiation pattern`.  The following code snippet is a simplified version of some of the essential bits of `create-class`:
 
 ```javascript
 function cmp(props, context, updater) {


### PR DESCRIPTION
"becausse" --> "because"